### PR TITLE
Init IPv6-monostack

### DIFF
--- a/projects/IPv6-monostack
+++ b/projects/IPv6-monostack
@@ -1,0 +1,15 @@
+{
+  pkgs,
+  sources,
+  ...
+}@args:
+{
+  packages = null;
+  nixos = {
+    modules = null;
+    examples = {
+      base = null;
+    };
+    tests = null;
+  };
+}


### PR DESCRIPTION
## IPv6-monostack
Commoditizing NAT64 and IP/ICMP translation to accelerate IPv6 deployment