### PR TITLE
Init WireGuard-SpinalHDL

### DIFF
--- a/projects/WireGuard-SpinalHDL
+++ b/projects/WireGuard-SpinalHDL
@@ -1,0 +1,15 @@
+{
+  pkgs,
+  sources,
+  ...
+}@args:
+{
+  packages = null;
+  nixos = {
+    modules = null;
+    examples = {
+      base = null;
+    };
+    tests = null;
+  };
+}


### PR DESCRIPTION
## WireGuard-SpinalHDL
FPGA implementation of Wireguard protocol written in SpinalHDL
### Websites
- https://github.com/likewise/BlackwireOverview