### PR TITLE
Init 5G-baseband-emulation

### DIFF
--- a/projects/5G-baseband-emulation
+++ b/projects/5G-baseband-emulation
@@ -1,0 +1,15 @@
+{
+  pkgs,
+  sources,
+  ...
+}@args:
+{
+  packages = null;
+  nixos = {
+    modules = null;
+    examples = {
+      base = null;
+    };
+    tests = null;
+  };
+}


### PR DESCRIPTION
## 5G-baseband-emulation
Easier testing of 5G baseband modems with FirmWire