### PR TITLE
Init Chromebook-UEFI

### DIFF
--- a/projects/Chromebook-UEFI
+++ b/projects/Chromebook-UEFI
@@ -1,0 +1,15 @@
+{
+  pkgs,
+  sources,
+  ...
+}@args:
+{
+  packages = null;
+  nixos = {
+    modules = null;
+    examples = {
+      base = null;
+    };
+    tests = null;
+  };
+}


### PR DESCRIPTION
## Chromebook-UEFI
Pre-built UEFI replacement firmware for ARM-based ChromeOS devices using coreboot/U-Boot
### Websites
- https://github.com/alpernebbi/u-boot/wiki